### PR TITLE
Setup expo-dev-client for development builds

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -1,19 +1,10 @@
 {
     "build": {
-      "preview": {
+      "development": {
         "android": {
           "buildType": "apk"
-        }
-      },
-      "preview2": {
-        "android": {
-          "gradleCommand": ":app:assembleRelease"
-        }
-      },
-      "preview3": {
-        "developmentClient": true
-      },
-      "preview4": {
+        },
+        "developmentClient": true,
         "distribution": "internal"
       },
       "production": {}

--- a/init.ts
+++ b/init.ts
@@ -4,6 +4,8 @@ import config from "./tamagui.config";
 
 // This import is needed before any UUID imports.
 import "react-native-get-random-values";
+// This import is needed for expo-dev-client error handling.
+import "expo-dev-client";
 
 export function initializeLibraries() {
   if (

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@tamagui/lucide-icons": "^1.89.26",
         "@types/react": "~18.2.14",
         "expo": "~50.0.7",
+        "expo-dev-client": "~3.3.8",
         "expo-font": "~11.10.2",
         "expo-linear-gradient": "~12.7.2",
         "expo-status-bar": "~1.11.1",
@@ -10536,6 +10537,136 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-dev-client": {
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-3.3.8.tgz",
+      "integrity": "sha512-6JpcxncWiWwq1w6SPrePpTa20z3D1qmAMMHd8f05lSCUPVBn4jTwpzrKEpGaA3EubLE5SEdxPVmvmyWw/oFFMQ==",
+      "dependencies": {
+        "expo-dev-launcher": "3.6.6",
+        "expo-dev-menu": "4.5.5",
+        "expo-dev-menu-interface": "1.7.2",
+        "expo-manifests": "~0.13.0",
+        "expo-updates-interface": "~0.15.1"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-launcher": {
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/expo-dev-launcher/-/expo-dev-launcher-3.6.6.tgz",
+      "integrity": "sha512-jVI1YZS1YJTrniIL53BOxSZUMyJCeDLuS9SlRx1vC3tnTTN3srg5pU/zCK/DifwbF7i6NtA1iLPSBVu2K4040A==",
+      "dependencies": {
+        "ajv": "8.11.0",
+        "expo-dev-menu": "4.5.5",
+        "expo-manifests": "~0.13.0",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.3"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-launcher/node_modules/ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/expo-dev-launcher/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/expo-dev-launcher/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/expo-dev-launcher/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/expo-dev-launcher/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/expo-dev-menu": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu/-/expo-dev-menu-4.5.5.tgz",
+      "integrity": "sha512-PcbI/SqAvueOIEtR1O0s+WvVD7yizQSqXisDSkBrTym3u8XZSN+K730kz2Z64ukY9YIPG4qWR4sd+9rcjsbMWw==",
+      "dependencies": {
+        "expo-dev-menu-interface": "1.7.2",
+        "semver": "^7.5.3"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-menu-interface": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu-interface/-/expo-dev-menu-interface-1.7.2.tgz",
+      "integrity": "sha512-V/geSB9rW0IPTR+d7E5CcvkV0uVUCE7SMHZqE/J0/dH06Wo8AahB16fimXeh5/hTL2Qztq8CQ41xpFUBoA9TEw==",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-menu/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/expo-dev-menu/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/expo-dev-menu/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
     "node_modules/expo-file-system": {
       "version": "16.0.6",
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-16.0.6.tgz",
@@ -10555,6 +10686,11 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-json-utils": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-0.12.3.tgz",
+      "integrity": "sha512-4pypQdinpNc6XY9wsZk56njvzDh+B/9mISr7FPP3CVk1QGB1nSLh883/BCDSgnsephATZkC5HG+cdE60kCAR6A=="
+    },
     "node_modules/expo-keep-awake": {
       "version": "12.8.2",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-12.8.2.tgz",
@@ -10567,6 +10703,18 @@
       "version": "12.7.2",
       "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-12.7.2.tgz",
       "integrity": "sha512-Wwb2EF18ywgrlTodcXJ6Yt/UEcKitRMdXPNyP/IokmeKh4emoq9DxZJpZdkXm3HUTLlbRpi6/t32jrFVqXB9AQ==",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-manifests": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-0.13.2.tgz",
+      "integrity": "sha512-l0Sia1WmLULx8V41K8RzGLsFoTe4qqthPRGpHjItsYn8ZB6lRrdTBM9OYp2McIflgqN1HAimUCQMFIwJyH+UmA==",
+      "dependencies": {
+        "@expo/config": "~8.5.0",
+        "expo-json-utils": "~0.12.0"
+      },
       "peerDependencies": {
         "expo": "*"
       }
@@ -10862,6 +11010,14 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/expo-status-bar/-/expo-status-bar-1.11.1.tgz",
       "integrity": "sha512-ddQEtCOgYHTLlFUe/yH67dDBIoct5VIULthyT3LRJbEwdpzAgueKsX2FYK02ldh440V87PWKCamh7R9evk1rrg=="
+    },
+    "node_modules/expo-updates-interface": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-0.15.3.tgz",
+      "integrity": "sha512-uLvsbaCmUsXgJqeen8rYH/jPr874ZUCXEvWpKHxrCv5/XATPlYEaDuecbNSGQ+cu78i6MdtB4BHOwZmoH2d47A==",
+      "peerDependencies": {
+        "expo": "*"
+      }
     },
     "node_modules/express": {
       "version": "4.18.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "react-native-web": "^0.19.10",
     "tamagui": "^1.89.26",
     "typescript": "^5.3.3",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "expo-dev-client": "~3.3.8"
   },
   "devDependencies": {
     "@babel/core": "^7.23.9",


### PR DESCRIPTION
I've been using simple local eas build, which has lead to a very slow turnaround time for mobile changes. This sets up the dev client so JS-only changes can be easily tested within seconds.